### PR TITLE
Find binaries with npm-which and execute with execa

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,17 @@ Configuration should be an object where each key is a file or directory mathed b
 
 ## What commands are supported?
 
-For now, only globally available commands are allowed. PRs welcome so local scripts are used first.
+Supported are any executables installed locally or globally via `npm` or Yarn as well as any executable from your `$PATH`.
+
+> Using globally installed scripts is discouraged, since run-if-changed may not work for someone who doesn't have it installed.
+
+`run-if-changed` is using [npm-which](https://github.com/timoxley/npm-which) to locate locally installed scripts. So in your `.run-if-changedrc` you can write:
+
+```json
+{
+  "src": "webpack"
+}
+```
 
 Sequences of commands are supported. Pass an array of commands instead of a single one and they will run sequentially.
 

--- a/find-binary.js
+++ b/find-binary.js
@@ -1,0 +1,25 @@
+const parseStringArgv = require('string-argv');
+const which = require('npm-which')(process.cwd());
+
+/*
+ *  Try to locate the binary in node_modules/.bin and if this fails, in $PATH.
+ *
+ *  This allows to use commands installed for the project:
+ *
+ *      "run-if-checked": {
+ *        "src": "webpack"
+ *      }
+ */
+module.exports = function findBinary(commandString) {
+  const [binaryName, ...args] = parseStringArgv(commandString);
+
+  /* npm-which tries to resolve the bin in local node_modules/.bin */
+  /* and if this fails it look in $PATH */
+  try {
+    const binaryPath = which.sync(binaryName);
+
+    return { binaryPath, args };
+  } catch (err) {
+    throw new Error(`${binaryName} binary not found! Probably try \`yarn install ${binaryName}\`.`);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "private": false,
   "dependencies": {
     "commander": "^2.19.0",
-    "cosmiconfig": "^5.0.7"
+    "cosmiconfig": "^5.0.7",
+    "execa": "^1.0.0",
+    "npm-which": "^3.0.1",
+    "string-argv": "^0.1.1"
   },
   "devDependencies": {
     "eslint": "^5.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2229,6 +2229,11 @@ string-argv@^0.0.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
   integrity sha1-2sMECGkMIfPDYwo/86BYd73L1zY=
 
+string-argv@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.1.tgz#66bd5ae3823708eaa1916fa5412703150d4ddfaf"
+  integrity sha512-El1Va5ehZ0XTj3Ekw4WFidXvTmt9SrC0+eigdojgtJMVtPkF0qbBe9fyNSl9eQf+kUHnTSQxdQYzuHfZy8V+DQ==
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"


### PR DESCRIPTION
This allows to run commands from locally installed binaries.
This also improves the execution with better escaping and piping of the output.