### PR TITLE
Run diff recursively to allow more granularity

### DIFF
--- a/src/gitChangedFilesSinceLastHead.js
+++ b/src/gitChangedFilesSinceLastHead.js
@@ -5,6 +5,7 @@ function getFilesFromGit() {
     'diff-tree',
     '--name-only',
     '--no-commit-id',
+    '-r',
     'HEAD@{1}',
     'HEAD',
   ]);


### PR DESCRIPTION
First of all, thanks for your work on this package, is very useful.

Currently diff only reports top level files and folders. For example, when `src/images/some-image.jpg` has changed it just reports `src`.

This is a constraint while trying to run commands with subfolder granularity. For example:

```
"run-if-changed": {
     "src/images/**": "npm run build:sprites"
}
```

In this case pattern will not match as it will be just compared against `src`.

This PR tries to address this issue running diff command with [recursive flag](https://git-scm.com/docs/git-diff-tree#Documentation/git-diff-tree.txt--r).