### PR TITLE
Remove commander dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "commander": "^2.19.0",
     "cosmiconfig": "^5.0.7",
     "execa": "^1.0.0",
     "micromatch": "^3.1.10",

--- a/run-if-changed.js
+++ b/run-if-changed.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-require('./src/cliInit')();
-
 const config = require('./src/configLoad')();
 const changedFiles = require('./src/gitChangedFilesSinceLastHead')();
 

--- a/src/cliInit.js
+++ b/src/cliInit.js
@@ -1,8 +1,0 @@
-const cli = require('commander');
-const pkg = require('../package.json');
-
-module.exports = function cliInit() {
-  cli
-    .version(pkg.version, '-v, --version')
-    .parse(process.argv);
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,7 +338,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-commander@^2.14.1, commander@^2.19.0, commander@^2.9.0:
+commander@^2.14.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==


### PR DESCRIPTION
It was supposed to be useful when running the binary as a CLI app.
If it only runs one thing and is run from a hook, the commander features are not needed.

Closes #12.