### PR TITLE
Publish via CI after testing on all supported node versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,45 +7,46 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 18, 20, 22 ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
-        node-version: 12
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     - name: npm install, build, and test
       run: |
         npm ci
         npm run build --if-present
         npm test
-      env:
-        CI: true
 
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          cache: 'npm'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-gpr:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          cache: 'npm'
           registry-url: https://npm.pkg.github.com/
-          scope: '@hkdobrev'
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "author": "Haralan Dobrev <hkdobrev@gmail.com>",
   "license": "MIT",
   "private": false,
+  "engines": {
+    "node": ">=18 <23"
+  },
   "dependencies": {
     "cosmiconfig": "^5.0.7",
     "execa": "^1.0.0",


### PR DESCRIPTION
Defined all currently active Node versions as supported.
Publishing to both GitHub package registry and npm package registry should happen automatically after creating a release and tests passing on all supported versions.