### PR TITLE
Exclude some of the changed files

### DIFF
--- a/src/gitChangedFilesSinceLastHead.js
+++ b/src/gitChangedFilesSinceLastHead.js
@@ -1,5 +1,6 @@
 import { execaSync } from 'execa';
 
-export default () => execaSync({ lines: true })`git diff-tree --name-only --no-commit-id -r HEAD@{1} HEAD`
+// Get the list of changed files since the previous HEAD from a git hook
+export default () => execaSync({ lines: true })`git diff-tree --name-only --no-commit-id --diff-filter=d --ignore-submodules -r HEAD@{1} HEAD`
   .stdout
   .filter((file) => !!file);


### PR DESCRIPTION
Exclude changed files detected from Git if:
- they have been deleted and not in the worktree
- they are changed in submodules

Both of these scenarios have some valid use cases for running commands on changes. E.g. refreshing a build after deleting files.
However, they are rare. E.g.:
-  If a file the command expects is now missing, the command may fail.
-  If a submodule is changed, a command might run unnecessarily.

⚠️  If there are users who would like these changes to still trigger command run, I think it's best done behind a configuration. 
👉  But the default behaviour should not be surprising and all of the use cases in the readme describe cases where these changes should not trigger command runs.