### PR TITLE
Deal with breaking change in cosmiconfig v9

### DIFF
--- a/src/configLoad.js
+++ b/src/configLoad.js
@@ -1,7 +1,9 @@
 import { cosmiconfigSync } from 'cosmiconfig';
 
 export default () => {
-  const configResult = cosmiconfigSync('run-if-changed').search();
+  const configResult = cosmiconfigSync('run-if-changed', {
+    searchStrategy: 'project',
+  }).search();
 
   if (!configResult || configResult.isEmpty) {
     process.exit(0);


### PR DESCRIPTION
Previously cosmiconfing was traversing upwards until root of the volume.
After [v9](https://github.com/cosmiconfig/cosmiconfig/blob/v9.0.0/CHANGELOG.md#900) it is only searching in the current working directory.

A good compromise is to apply the new `searchStrategy` option and look upwards until the `package.json` folder. So the binary would still work when run from a nested directory in the project.