### PR TITLE
Extend support for Node.js up to version 24

### DIFF
--- a/.github/workflows/js_test.yml
+++ b/.github/workflows/js_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18, 20, 22 ]
+        node-version: [ 18, 20, 22, 24 ]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18, 20, 22 ]
+        node-version: [ 18, 20, 22, 24 ]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "lint-staged": "^16.0.0"
       },
       "engines": {
-        "node": ">=18 <23"
+        "node": ">=18 <25"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "type": "module",
   "engines": {
-    "node": ">=18 <23"
+    "node": ">=18 <25"
   },
   "dependencies": {
     "cosmiconfig": "^9.0.0",


### PR DESCRIPTION
Node.js 24 has been released as a Current Release:
https://nodejs.org/en/about/previous-releases

This pull request adds support for Node.js 24 to our tool.