### PR TITLE
Use npm trusted publishing (OIDC) for CI releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,12 +33,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
+          node-version: 24
           cache: 'npm'
           registry-url: https://registry.npmjs.org/
+      # Trusted publishing via OIDC requires npm >= 11.5.1; no NPM_TOKEN needed.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-gpr:
     needs: build


### PR DESCRIPTION
Switch the npm publish job to OIDC-based [trusted publishing](https://docs.npmjs.com/trusted-publishers), removing the long-lived `NPM_TOKEN`.

## Why
The `NPM_TOKEN` secret had expired, causing `npm publish` to fail with `E404` on `PUT` (both `0.7.0` today and `0.6.4` back in Aug 2025). Trusted publishing uses short-lived OIDC tokens minted per-run, so there's nothing to expire.

## Changes
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step.
- Pin Node 24 and run `npm install -g npm@latest` (OIDC publishing requires npm >= 11.5.1).
- `id-token: write` permission was already present.

## Required out-of-band setup
A Trusted Publisher must be configured on npmjs.com for `@hkdobrev/run-if-changed` pointing at this repo + `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)