### PR TITLE
Add unit tests with the built-in Node.js test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "oxlint": "^1.71.0"
   },
   "scripts": {
-    "test": "oxlint && oxfmt --check run-if-changed.js src",
+    "test": "oxlint && oxfmt --check run-if-changed.js src && node --test",
+    "test:unit": "node --test",
+    "test:watch": "node --test --watch",
     "lint": "oxlint",
     "format": "oxfmt run-if-changed.js src",
     "preversion": "npm run test",

--- a/src/__tests__/configLoad.test.js
+++ b/src/__tests__/configLoad.test.js
@@ -1,0 +1,46 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import configLoad from '../configLoad.js';
+
+// `configLoad` resolves real config files via cosmiconfig, so each test runs
+// inside an isolated temp directory. A bare package.json makes it a project
+// root, so cosmiconfig's 'project' search strategy stops there and never
+// reaches the real repository above.
+
+let dir;
+let originalCwd;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), 'rif-config-'));
+  writeFileSync(join(dir, 'package.json'), '{}\n');
+  process.chdir(dir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(dir, { recursive: true, force: true });
+  mock.restoreAll();
+});
+
+describe('configLoad', () => {
+  it('returns the config discovered by cosmiconfig', () => {
+    const config = { 'package-lock.json': ['npm install'] };
+    writeFileSync(join(dir, '.run-if-changedrc.json'), JSON.stringify(config));
+
+    assert.deepEqual(configLoad(), config);
+  });
+
+  it('exits with code 0 when no config is found', () => {
+    const exit = mock.method(process, 'exit', () => {
+      throw new Error('process.exit called');
+    });
+
+    assert.throws(() => configLoad(), /process\.exit called/);
+    assert.deepEqual(exit.mock.calls[0].arguments, [0]);
+  });
+});

--- a/src/__tests__/gitChangedFilesSinceLastHead.test.js
+++ b/src/__tests__/gitChangedFilesSinceLastHead.test.js
@@ -1,0 +1,59 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import gitChangedFilesSinceLastHead from '../gitChangedFilesSinceLastHead.js';
+
+// The module shells out to `git diff-tree ... HEAD@{1} HEAD`, so we build a
+// throwaway repository with two commits and run against it for real.
+
+const git = (cwd, ...args) =>
+  execFileSync('git', args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+
+describe('gitChangedFilesSinceLastHead', () => {
+  let dir;
+  let originalCwd;
+
+  before(() => {
+    originalCwd = process.cwd();
+    dir = mkdtempSync(join(tmpdir(), 'rif-git-'));
+    git(dir, 'init', '-q');
+
+    writeFileSync(join(dir, 'first.txt'), 'a\n');
+    git(dir, 'add', '.');
+    git(dir, 'commit', '-qm', 'first');
+
+    // The second commit changes only second.txt; after it, HEAD@{1} points at
+    // the first commit, so the diff against HEAD should be exactly second.txt.
+    writeFileSync(join(dir, 'second.txt'), 'b\n');
+    git(dir, 'add', '.');
+    git(dir, 'commit', '-qm', 'second');
+
+    process.chdir(dir);
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('lists files changed since the previous HEAD', () => {
+    assert.deepEqual(gitChangedFilesSinceLastHead(), ['second.txt']);
+  });
+
+  it('does not include empty strings', () => {
+    assert.ok(gitChangedFilesSinceLastHead().every((file) => file !== ''));
+  });
+});

--- a/src/__tests__/resolveMatchingPatterns.test.js
+++ b/src/__tests__/resolveMatchingPatterns.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import resolveMatchingPatterns from '../resolveMatchingPatterns.js';
+
+describe('resolveMatchingPatterns', () => {
+  it('returns the commands for a matching pattern', () => {
+    const result = resolveMatchingPatterns(['package-lock.json'], {
+      'package-lock.json': ['npm install'],
+    });
+
+    assert.deepEqual(result, ['npm install']);
+  });
+
+  it('returns an empty array when no pattern matches', () => {
+    const result = resolveMatchingPatterns(['README.md'], {
+      'package-lock.json': ['npm install'],
+    });
+
+    assert.deepEqual(result, []);
+  });
+
+  it('returns an empty array when no files changed', () => {
+    const result = resolveMatchingPatterns([], {
+      'package-lock.json': ['npm install'],
+    });
+
+    assert.deepEqual(result, []);
+  });
+
+  it('flattens commands from multiple matching patterns', () => {
+    const result = resolveMatchingPatterns(['package-lock.json', 'yarn.lock'], {
+      'package-lock.json': ['npm install', 'npm audit'],
+      'yarn.lock': ['yarn install'],
+    });
+
+    assert.deepEqual(result, ['npm install', 'npm audit', 'yarn install']);
+  });
+
+  it('deduplicates a command shared by several matching patterns', () => {
+    const result = resolveMatchingPatterns(['package-lock.json', 'yarn.lock'], {
+      'package-lock.json': ['npm install'],
+      'yarn.lock': ['npm install'],
+    });
+
+    assert.deepEqual(result, ['npm install']);
+  });
+
+  it('deduplicates a command repeated within a single pattern', () => {
+    const result = resolveMatchingPatterns(['package-lock.json'], {
+      'package-lock.json': ['npm install', 'npm install'],
+    });
+
+    assert.deepEqual(result, ['npm install']);
+  });
+
+  it('supports glob patterns', () => {
+    const result = resolveMatchingPatterns(['src/deep/index.js'], {
+      'src/**/*.js': ['npm test'],
+    });
+
+    assert.deepEqual(result, ['npm test']);
+  });
+});

--- a/src/__tests__/runCommands.test.js
+++ b/src/__tests__/runCommands.test.js
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import runCommands from '../runCommands.js';
+
+// `runCommands` builds a Listr task list and executes each command with
+// execaCommandSync. We exercise the real behaviour with harmless shell
+// builtins (`true` succeeds, `false` exits non-zero) instead of mocking.
+
+describe('runCommands', () => {
+  it('resolves when every command succeeds', async () => {
+    await assert.doesNotReject(runCommands(['true', 'true']));
+  });
+
+  it('accepts a single command as a string', async () => {
+    await assert.doesNotReject(runCommands('true'));
+  });
+
+  it('rejects when a command exits non-zero', async () => {
+    await assert.rejects(runCommands(['false']));
+  });
+
+  it('ignores falsy commands', async () => {
+    // Only falsy entries means no task runs and nothing fails.
+    await assert.doesNotReject(runCommands(['', null, undefined, false]));
+  });
+
+  it('runs a real command, observable through its side effect', async () => {
+    const marker = `node-test-${process.pid}`;
+    await runCommands([`test "${marker}" = "${marker}"`]);
+    // A failing comparison would reject; reaching here means it ran and passed.
+    await assert.rejects(runCommands([`test "${marker}" = "other"`]));
+  });
+});


### PR DESCRIPTION
Adds unit tests for all four `src/` modules using Node's built-in test runner (`node:test` + `node:assert`) — **zero new dependencies**, native ESM, no experimental flags, runs across the supported Node range (20.19+/22/24).

## Approach
Behaviour-focused rather than mock-everything:
- **resolveMatchingPatterns** — pure: matching, no-match, flatten, dedup (across and within patterns), globs.
- **runCommands** — runs real harmless commands (`true`/`false`) to verify success, single-string input, non-zero rejection, and falsy filtering.
- **configLoad** — loads a real cosmiconfig fixture from an isolated temp dir; covers the `process.exit(0)` no-config path via the stable `mock.method` (no module mocking).
- **gitChangedFilesSinceLastHead** — runs against a throwaway two-commit git repo.

`npm test` now runs `oxlint && oxfmt --check … && node --test`, so the existing CI/`preversion` gate covers lint, format, and tests. Added `test:unit` and `test:watch` for development.

## Relationship to #164
This supersedes #164 (which used Jest + `--experimental-vm-modules` and predated the oxc migration). The test cases are adapted from that PR — thanks @bpneal — but re-implemented on the built-in runner to avoid the extra dependency tree. #164 will be closed in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)