### PR TITLE
Ship only runtime files in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Run a command if a file changes via Git hooks",
   "bin": "run-if-changed.js",
   "exports": "./run-if-changed.js",
+  "files": [
+    "run-if-changed.js",
+    "src/*.js"
+  ],
   "repository": "https://github.com/hkdobrev/run-if-changed",
   "author": "Haralan Dobrev <harry@hkdobrev.com>",
   "license": "MIT",


### PR DESCRIPTION
Add a `files` allowlist so the published tarball contains only the runtime code (run-if-changed.js + src/*.js), instead of the whole repo (workflows, husky hooks, _includes, .claude, tests). README/LICENSE/package.json are always included by npm; `src/*.js` excludes the src/__tests__/ subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)